### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/coverage/sorter.js
+++ b/coverage/sorter.js
@@ -24,6 +24,15 @@ var addSorting = (function() {
         return getTableHeader().querySelectorAll('th')[n];
     }
 
+    function escapeHtml(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function onFilterInput() {
         const searchValue = document.getElementById('fileSearch').value;
         const rows = document.getElementsByTagName('tbody')[0].children;
@@ -88,6 +97,8 @@ var addSorting = (function() {
             val = colNode.getAttribute('data-value');
             if (col.type === 'number') {
                 val = Number(val);
+            } else if (val !== null && val !== undefined) {
+                val = escapeHtml(val);
             }
             data[col.key] = val;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/achudars/alekscudars.com/security/code-scanning/2](https://github.com/achudars/alekscudars.com/security/code-scanning/2)

To fix the vulnerability, we need to ensure that data obtained from `colNode.getAttribute('data-value')` (i.e., the `.data-value` attribute on each table cell) cannot enable XSS if later rendered as HTML. This generally requires sanitizing or escaping the value when it is read, *before* inserting it into any object that could later be rendered as HTML.

Since we only have access to the current file and can't control its usage elsewhere, the best mitigation is to encode the value at the point of reading. If the column is of type 'string', we should ensure meta-characters like `<`, `>`, `&`, `"`, and `'` are replaced with their HTML-escaped equivalents as soon as the value is read.

To accomplish this:
- In `loadRowData`, just after reading `val` for non-numeric values, pass it through an escaping function.
- We need to implement a small helper function, e.g. `escapeHtml`, that does the HTML-escaping.
- Add the helper function in this file (as we've only seen this file).
- Use this helper so that when storing to `data[col.key]`, non-numeric values are HTML-escaped.

All this is to be done strictly within the code shown, i.e., changes within `coverage/sorter.js` only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
